### PR TITLE
docker-compose: hide ports, persistent DB, etc.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,39 @@
 version: "3.8"
 services:
 
- db:
-  image: postgres:13.1-alpine
-  environment:
-   - POSTGRES_PASSWORD=password
-  ports:
-   - 5432:5432
-  volumes:
-   - ./server/db_script/changd.sql:/docker-entrypoint-initdb.d/changd.sql
-  restart: always
+  db:
+    container_name: changd-db
+    image: postgres:alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_PASSWORD=password
+    # ports:
+    #  - 5432:5432
+    volumes:
+      - ./server/db_script/changd.sql:/docker-entrypoint-initdb.d/changd.sql
+      - ./db-data:/var/lib/postgresql/data
 
- api:
-  depends_on:
-   - db
-  build:
-   context: ./server
-   dockerfile: Dockerfile
+  api:
+    container_name: changd-api
+    restart: unless-stopped
+    depends_on:
+      - db
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    # ports:
+    #   - ${PORT_API-8000}:8000
+    volumes:
+      - /app/node_modules
 
-  ports:
-   - 8000:8000
-  volumes:
-   - /app/node_modules
-
- ui_server:
-  depends_on:
-   - api
-  image: nginx:1.19.4-alpine
-  ports:
-   - 80:80
-  volumes:
-   - ./frontend/build:/usr/share/nginx/html
-   - ./frontend/nginx/default.conf:/etc/nginx/conf.d/default.conf
+  ui_server:
+    container_name: changd-ui
+    image: nginx:alpine
+    restart: unless-stopped
+    depends_on:
+      - api
+    ports:
+      - ${PORT-80}:80
+    volumes:
+      - ./frontend/build:/usr/share/nginx/html
+      - ./frontend/nginx/default.conf:/etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Changes:
- use DB volume to make the data persistent
- ports for api and db do not need to be exposed
- remove explicit versions for DB and Nginx
- restart unless stopped
- explicit container_name
- use optional environment variables to set the external port(s)